### PR TITLE
Fix blank screen by using import.meta.env for Supabase

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+// Vite exposes environment variables through `import.meta.env` in the browser
+// context. Using `process.env` causes a runtime error because `process` is not
+// defined when the code runs in the browser. The original code attempted to
+// read the Supabase credentials via `process.env`, which resulted in an
+// exception and caused the site to render a blank page. By switching to
+// `import.meta.env` we ensure the values are replaced at build time.
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey); 
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || '';
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- replace `process.env` with `import.meta.env` in `supabaseClient.ts`
- add comments explaining why

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68530f550d688331acd6bf17ab73ef7c