### PR TITLE
Fix blank screen by supporting NEXT_PUBLIC vars

### DIFF
--- a/lib/supabasClient.ts
+++ b/lib/supabasClient.ts
@@ -1,7 +1,0 @@
-// src/lib/supabaseClient.ts
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = 'https://aotdddgoudzcykkgeojf.supabase.co'; // 
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFvdGRkZGdvdWR6Y3lra2dlb2pmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAwMDY2MzksImV4cCI6MjA2NTU4MjYzOX0.v6uiDStU2DRGJLXYwmIMe7mKDQO60pinF-15oBlobfc'; // 
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,23 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+// Vite exposes environment variables through `import.meta.env` in the browser
+// context. Using `process.env` causes a runtime error because `process` is not
+// defined when the code runs in the browser. The original code attempted to
+// read the Supabase credentials via `process.env`, which resulted in an
+// exception and caused the site to render a blank page. By switching to
+// `import.meta.env` we ensure the values are replaced at build time.
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey); 
+// Support both the `VITE_` and `NEXT_PUBLIC_` prefixes so the project works
+// whether the variables are defined in a Vite-style `.env` file or in a
+// Vercel environment configured for Next.js. Vite only exposes variables with
+// prefixes listed in `envPrefix` (see `vite.config.ts`).
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL ||
+  import.meta.env.NEXT_PUBLIC_SUPABASE_URL ||
+  '';
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -8,16 +8,18 @@ import { createClient } from '@supabase/supabase-js';
 // `import.meta.env` we ensure the values are replaced at build time.
 
 // Support both the `VITE_` and `NEXT_PUBLIC_` prefixes so the project works
-// whether the variables are defined in a Vite-style `.env` file or in a
-// Vercel environment configured for Next.js. Vite only exposes variables with
+// whether variables are defined in a Vite-style `.env` file or in a Vercel
+// environment configured for Next.js. Vite only exposes variables with
 // prefixes listed in `envPrefix` (see `vite.config.ts`).
-const supabaseUrl =
-  import.meta.env.VITE_SUPABASE_URL ||
-  import.meta.env.NEXT_PUBLIC_SUPABASE_URL ||
-  '';
+const {
+  VITE_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_URL,
+  VITE_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY
+} = import.meta.env;
+
+const supabaseUrl = VITE_SUPABASE_URL || NEXT_PUBLIC_SUPABASE_URL || '';
 const supabaseAnonKey =
-  import.meta.env.VITE_SUPABASE_ANON_KEY ||
-  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-  '';
+  VITE_SUPABASE_ANON_KEY || NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   root: '.',
   plugins: [react()],
+  // Expose both `VITE_` and `NEXT_PUBLIC_` environment variables to the client
+  // so deployments configured for Next.js continue to work without changes.
+  envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   build: {
     outDir: 'dist'
   }


### PR DESCRIPTION
## Summary
- support `NEXT_PUBLIC_` Supabase vars for Vercel deployments
- document multi-prefix Supabase env handling
- expose `NEXT_PUBLIC_` prefix via `vite.config.ts`
- remove unused duplicate `supabasClient.ts`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68530f550d688331acd6bf17ab73ef7c