### PR TITLE
Fix blank screen due to Supabase init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Workspace2.0
+
+This project uses React and Vite.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Environment variables
+
+To enable waitlist submissions through Supabase, set the following variables in a `.env` file or through your hosting platform:
+
+```
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+```
+
+If these are not provided, the site will still render but submissions will be skipped.

--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -10,6 +10,12 @@ export default function CTA() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    if (!supabase) {
+      console.error('Supabase client not initialized. Skipping submission.');
+      setSubmitted(true);
+      return;
+    }
+
     const { error } = await supabase.from('waitlist').insert([{ email }]);
 
     if (error) {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 // Vite injects env vars on build via `import.meta.env`.
 // We support both `VITE_` and `NEXT_PUBLIC_` prefixes so the code
@@ -14,4 +14,12 @@ const supabaseUrl = VITE_SUPABASE_URL ?? NEXT_PUBLIC_SUPABASE_URL ?? '';
 const supabaseAnonKey =
   VITE_SUPABASE_ANON_KEY ?? NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+let supabase: SupabaseClient | null = null;
+
+if (supabaseUrl && supabaseAnonKey) {
+  supabase = createClient(supabaseUrl, supabaseAnonKey);
+} else {
+  console.warn('Supabase environment variables missing; client not initialized.');
+}
+
+export { supabase };


### PR DESCRIPTION
## Summary
- guard Supabase client initialization when credentials are missing
- make CTA component handle a `null` Supabase client gracefully
- add a README with setup instructions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685321debaf8833187fb7445ffa8c45a